### PR TITLE
Add Physical AI Atlas to Related Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,7 @@
 - Awesome-BFM-Papers [[repo](https://github.com/yuanmingqi/awesome-bfm-papers)]
 - Awesome-Physical-AI [[repo](https://github.com/keon/awesome-physical-ai)]
 - Awesome VLA Study [[repo](https://github.com/MilkClouds/awesome-vla-study)]
+- Physical AI Atlas — open dataset (CC BY 4.0) of the physical AI ecosystem: humanoid robots, industrial platforms, VLA models, embedded chips, simulators and labs, bilingual FR/EN and dated per entry [[repo](https://github.com/PlbKin190/physical-ai-atlas-data)] [[site](https://www.d-fairy.fr/atlas/)]
 
 ## Star History
 


### PR DESCRIPTION
Adds the Physical AI Atlas to **Related Works**.

Unlike the other entries in that section, this one is not a paper list: it is an open dataset (CC BY 4.0) indexing the entities of the physical AI ecosystem — humanoid robots, industrial platforms, VLA models, embedded AI chips, simulators and labs — as machine-readable JSON with a published schema. Bilingual FR/EN, each entity carrying its own verification date and sources.

Useful next to this list when you need the hardware and deployment side of the picture rather than the model literature.

Repository: https://github.com/PlbKin190/physical-ai-atlas-data
Browsable: https://www.d-fairy.fr/atlas/

Disclosure: I maintain the Atlas. Happy to shorten the entry or move it if another section fits better.
